### PR TITLE
Make .htaccess hybrid to be compatible with Apache 2.2 and Apache 2.4

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,7 +11,7 @@
 # Apache 2.4
 <IfModule mod_authz_core.c>
 	<Files config.ini>
-        Require all denied
+		Require all denied
 	</Files>
 </IfModule>
 

--- a/.htaccess
+++ b/.htaccess
@@ -7,6 +7,18 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L,NC]
 </IfModule>
-<Files config.ini>
-    Require all denied
-</Files>
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	<Files config.ini>
+        Require all denied
+	</Files>
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	<Files config.ini>
+		Order Allow,Deny
+		Deny from all
+	</Files>
+</IfModule>

--- a/.htaccess
+++ b/.htaccess
@@ -2,7 +2,7 @@
     Options -MultiViews +SymLinksIfOwnerMatch
 
     RewriteEngine On
-    #RewriteBase /path/to/gitlist/
+    RewriteBase /
 
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L,NC]

--- a/.htaccess
+++ b/.htaccess
@@ -5,9 +5,8 @@
     #RewriteBase /path/to/gitlist/
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^(.*)$ index.php/$1 [L,NC]
+    RewriteRule ^ index.php [L,NC]
 </IfModule>
 <Files config.ini>
-    order allow,deny
-    deny from all
+    Require all denied
 </Files>


### PR DESCRIPTION
You could always enable mod_access_compat module on Apache 2.4 to have backwards compatibility with Apache 2.2 .htaccess access control directives. Unfortunately it is not always possible, so it would be better to fix it.